### PR TITLE
added null check in upperBound

### DIFF
--- a/lib/treebase.js
+++ b/lib/treebase.js
@@ -78,7 +78,7 @@ TreeBase.prototype.upperBound = function(item) {
     var iter = this.lowerBound(item);
     var cmp = this._comparator;
 
-    while(cmp(iter.data(), item) === 0) {
+    while(iter.data() !== null && cmp(iter.data(), item) === 0) {
         iter.next();
     }
 

--- a/test/test_api.js
+++ b/test/test_api.js
@@ -195,6 +195,11 @@ function upper_bound(assert, tree_class) {
     assert.equal(iter.data(), null);
     iter = tree.upperBound(last + 1);
     assert.equal(iter.data(), null);
+
+    // test empty
+    var empty = new tree_class(function(a,b) { return a.val - b.val });
+    var iter = empty.upperBound({val:0});
+    assert.equal(iter.data(), null);
 }
 
 function find(assert, tree_class) {


### PR DESCRIPTION
I've been using a comparator function that references fields in an object, and noticed that upperBound was sometimes calling cmp with a null argument. This fixes that.
