### PR TITLE
Dependency cleanup

### DIFF
--- a/dist/bintree.js
+++ b/dist/bintree.js
@@ -297,7 +297,6 @@ BinTree.prototype.insert = function(data) {
             // insert new node at the bottom
             node = new Node(data);
             p.set_child(dir, node);
-            ret = true;
             this.size++;
             return true;
         }

--- a/lib/bintree.js
+++ b/lib/bintree.js
@@ -49,7 +49,6 @@ BinTree.prototype.insert = function(data) {
             // insert new node at the bottom
             node = new Node(data);
             p.set_child(dir, node);
-            ret = true;
             this.size++;
             return true;
         }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "devDependencies": {
     "nodeunit": "0.9.1",
     "jshint": "0.5.9",
-    "underscore": "1.3.1",
     "reunion": "0.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,13 +18,22 @@
   },
   "main": "./index.js",
   "scripts": {
-    "test": "nodeunit ./test/test_*.js && jshint lib/*.js index.js"
+    "pretest": "eslint lib/*.js index.js test/*.js",
+    "test": "nodeunit ./test/test_*.js"
   },
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
+    "eslint": "^2.13.0",
     "nodeunit": "0.9.1",
-    "jshint": "0.5.9",
-    "reunion": "0.0.0"
+    "reunion": "0.0.1"
+  },
+  "eslintConfig": {
+    "extends": "eslint:recommended",
+    "env": {
+      "node": true
+    },
+    "rules": {
+      "no-constant-condition": 0
+    }
   }
 }

--- a/test/loader.js
+++ b/test/loader.js
@@ -1,5 +1,4 @@
 var fs = require('fs');
-var _ = require('underscore');
 
 function load(filename) {
     var ret = [];
@@ -15,11 +14,11 @@ function load(filename) {
 }
 
 function get_inserts(tests) {
-    return _.select(tests, function(n) { return n > 0; });
+    return tests.filter(function(n) { return n > 0; });
 }
 
 function get_removes(tests) {
-    return _.select(tests, function(n) { return n < 0; });
+    return tests.filter(function(n) { return n < 0; });
 }
 
 function new_tree(tree_type) {

--- a/test/perf_test.js
+++ b/test/perf_test.js
@@ -6,6 +6,8 @@ var NUM_TIMES = 10;
 var BASE_DIR = __dirname + '/perf';
 var TREES = ['../test/arrtree', 'rbtree', 'bintree'];
 
+/* eslint no-console: 0 */
+
 function mean(arr) {
     var sum = 0;
     arr.forEach(function(n) {

--- a/test/test_api.js
+++ b/test/test_api.js
@@ -159,6 +159,7 @@ function switch_it(assert, tree_class) {
             items.push(it.next());
         }
 
+        var data;
         while((data = it.prev()) !== null) {
             items.push(data);
         }
@@ -189,13 +190,14 @@ function empty_it(assert, tree_class) {
 function lower_bound(assert, tree_class) {
     var inserts = loader.get_inserts(loader.load(SAMPLE_FILE));
     var tree = loader.build_tree(tree_class, inserts);
+    var iter;
 
     inserts.sort(function(a,b) { return a - b; });
 
     for(var i=1; i<inserts.length-1; ++i) {
         var item = inserts[i];
 
-        var iter = tree.lowerBound(item);
+        iter = tree.lowerBound(item);
         assert.equal(iter.data(), item);
         assert.equal(iter.prev(), inserts[i-1]);
         iter.next();
@@ -209,7 +211,7 @@ function lower_bound(assert, tree_class) {
     }
 
     // test edges
-    var iter = tree.lowerBound(-1);
+    iter = tree.lowerBound(-1);
     assert.equal(iter.data(), inserts[0]);
     var last = inserts[inserts.length - 1];
     iter = tree.lowerBound(last);
@@ -221,13 +223,14 @@ function lower_bound(assert, tree_class) {
 function upper_bound(assert, tree_class) {
     var inserts = loader.get_inserts(loader.load(SAMPLE_FILE));
     var tree = loader.build_tree(tree_class, inserts);
+    var iter;
 
     inserts.sort(function(a,b) { return a - b; });
 
     for(var i=0; i<inserts.length-2; ++i) {
         var item = inserts[i];
 
-        var iter = tree.upperBound(item);
+        iter = tree.upperBound(item);
         assert.equal(iter.data(), inserts[i+1]);
         assert.equal(iter.prev(), inserts[i]);
         iter.next();
@@ -241,7 +244,7 @@ function upper_bound(assert, tree_class) {
     }
 
     // test edges
-    var iter = tree.upperBound(-1);
+    iter = tree.upperBound(-1);
     assert.equal(iter.data(), inserts[0]);
     var last = inserts[inserts.length - 1];
     iter = tree.upperBound(last);
@@ -251,7 +254,7 @@ function upper_bound(assert, tree_class) {
 
     // test empty
     var empty = new tree_class(function(a,b) { return a.val - b.val });
-    var iter = empty.upperBound({val:0});
+    iter = empty.upperBound({val:0});
     assert.equal(iter.data(), null);
 }
 

--- a/test/test_api.js
+++ b/test/test_api.js
@@ -1,5 +1,3 @@
-var _ = require('underscore');
-
 var loader = require('./loader');
 
 var SAMPLE_FILE = __dirname + '/samples/10k';
@@ -44,8 +42,8 @@ function minmax(assert, tree_class) {
     var inserts = loader.get_inserts(loader.load(SAMPLE_FILE));
     tree = loader.build_tree(tree_class, inserts);
 
-    assert.equal(tree.min(), _.min(inserts));
-    assert.equal(tree.max(), _.max(inserts));
+    assert.equal(tree.min(), Math.min.apply(Math, inserts));
+    assert.equal(tree.max(), Math.max.apply(Math, inserts));
 }
 
 function forward_it(assert, tree_class) {


### PR DESCRIPTION
- Removes unnecessary Underscore dependency
- Replaces the legacy JSHint with the industry standard ESlint
- Fixes some stuff that wasn’t caught by JSHint earlier