### PR TITLE
Tree#insert: replace data with the supplied data if it compares equal

### DIFF
--- a/lib/bintree.js
+++ b/lib/bintree.js
@@ -55,6 +55,8 @@ BinTree.prototype.insert = function(data) {
 
         // stop if found
         if(this._comparator(node.data, data) === 0) {
+            // overwrite the node with the supplied data
+            node.data = data;
             return false;
         }
 

--- a/lib/rbtree.js
+++ b/lib/rbtree.js
@@ -84,6 +84,8 @@ RBTree.prototype.insert = function(data) {
 
             // stop if found
             if(cmp === 0) {
+                // overwrite the node with the supplied data
+                node.data = data;
                 break;
             }
 

--- a/test/test_correctness.js
+++ b/test/test_correctness.js
@@ -112,6 +112,16 @@ TREES.forEach(function(tree) {
           assert.done();
        };
     });
+
+    /* Tweaked behaviour: want reinserting a node that compares equal with an existing node to
+     * still replace the data */
+    test_funcs[tree + "_test_insert_matching"] = function(assert) {
+        var tree = new tree_class((a, b) => a.score - b.score);
+        tree.insert({score: 1, id: 1});
+        tree.insert({score: 1, id: 2});
+        assert.equal(tree.find({score: 1}).id, 2);
+        assert.done();
+    };
 });
 
 exports.correctness = test_funcs;


### PR DESCRIPTION
Allows usecases where entries can be objects compared by some score or whatever, but still replaced with `insert` by some newer version of the object with the same score.

(not sure if this project is actively developed, but putting it here anyway in case anyone else might want to use it)