### PR TITLE
ship only production runtime files

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,11 @@
     "lib": "lib"
   },
   "main": "./index.js",
+  "files": [
+    "lib",
+    "dist",
+    "index.js"
+  ],
   "scripts": {
     "test": "nodeunit ./test/test_*.js && jshint lib/*.js index.js"
   },


### PR DESCRIPTION
This change will reduce your node_modules on-disk footprint by 97%, from 2.3M to 80K.

The reason is that you ship in your package your tests and your test data, and you do have good tests with large test data samples... :P 

tests files, dev-config files, docs and fixture data are not meant to be shipped in the package.

Current situation:
```
$ du -ah node_modules/bintrees
4.0K    node_modules/bintrees/examples/node.js
4.0K    node_modules/bintrees/examples/client.html
12.0K   node_modules/bintrees/examples
4.0K    node_modules/bintrees/README.md
4.0K    node_modules/bintrees/test/arrtree.js
2.0M    node_modules/bintrees/test/perf/100k
2.0M    node_modules/bintrees/test/perf
4.0K    node_modules/bintrees/test/loader.js
4.0K    node_modules/bintrees/test/test_correctness.js
4.0K    node_modules/bintrees/test/scripts/gen_test.js
8.0K    node_modules/bintrees/test/scripts
204.0K  node_modules/bintrees/test/samples/10k
208.0K  node_modules/bintrees/test/samples
12.0K   node_modules/bintrees/test/test_api.js
4.0K    node_modules/bintrees/test/perf_test.js
2.2M    node_modules/bintrees/test
12.0K   node_modules/bintrees/dist/rbtree.js
8.0K    node_modules/bintrees/dist/bintree.js
4.0K    node_modules/bintrees/dist/bintree.min.js
8.0K    node_modules/bintrees/dist/rbtree.min.js
36.0K   node_modules/bintrees/dist
8.0K    node_modules/bintrees/lib/rbtree.js
4.0K    node_modules/bintrees/lib/bintree.js
8.0K    node_modules/bintrees/lib/treebase.js
24.0K   node_modules/bintrees/lib
4.0K    node_modules/bintrees/index.js
4.0K    node_modules/bintrees/Makefile
4.0K    node_modules/bintrees/package.json
4.0K    node_modules/bintrees/.npmignore
4.0K    node_modules/bintrees/LICENSE
4.0K    node_modules/bintrees/.travis.yml
2.3M    node_modules/bintrees
```

after change:
```
 du -h node_modules/bintrees                                                                                                                     <aws:lwf>
36K     node_modules/bintrees/dist
24K     node_modules/bintrees/lib
80K     node_modules/bintrees
```

pacakge size reduces as well:

```
$  ls -lah *.tgz                                                                                                                                       <aws:lwf>
-rw-r--r-- 1 osher osher 1.1M May  5 22:04 bintrees-1.0.2.before.tgz
-rw-r--r-- 1 osher osher 4.8K May  5 22:10 bintrees-1.0.2.no-dist.tgz
-rw-r--r-- 1 osher osher 7.1K May  5 22:19 bintrees-1.0.2.tgz
```

I'm not sure about `dist`. Most web-apps do their own bundling and compacting...
However, if you chose not to ship dist - you'll be breaking compatibility and should raise a major.